### PR TITLE
fix: `getPrefix()` method doesn't exist in Model class

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -272,6 +272,11 @@ abstract class Model implements ArrayAccess, JsonSerializable
         return $this->table;
     }
 
+    public function getPrefix()
+    {
+        return $this->prefix === '' ? Connection::getPrefix() : $this->prefix;
+    }
+
     public function getTableWithoutPrefix()
     {
         return $this->_tableWithoutPrefix;


### PR DESCRIPTION
`getPrefix()` calling from `QueryBuilder.php` file inside `join` method.