### PR TITLE
feat: Add optional prefix parameter to foreign method 

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -443,14 +443,12 @@ class Blueprint
 
     public function foreign($ref, $refCol, $prefix = null)
     {
-        $newPrefix = $prefix ?? $this->_prefix;
-
-        $ref = $newPrefix . $ref;
+        $prefix = $prefix ?? $this->_prefix;
 
         $this->fkID = \count($this->foreignKeys);
         $this->foreignKeys[] = [
             'column'  => $this->columns[$this->columnIndex]['name'],
-            'ref'     => $ref,
+            'ref'     =>  $prefix . $ref,
             'ref_col' => $refCol,
         ];
 

--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -441,12 +441,16 @@ class Blueprint
         return $this;
     }
 
-    public function foreign($ref, $refCol)
+    public function foreign($ref, $refCol, $prefix = null)
     {
-        $this->fkID          = \count($this->foreignKeys);
+        $newPrefix = $prefix ?? $this->_prefix;
+
+        $ref = $newPrefix . $ref;
+
+        $this->fkID = \count($this->foreignKeys);
         $this->foreignKeys[] = [
             'column'  => $this->columns[$this->columnIndex]['name'],
-            'ref'     => $this->_prefix . $ref,
+            'ref'     => $ref,
             'ref_col' => $refCol,
         ];
 


### PR DESCRIPTION
This update is helpful for pro database migrations where foreign keys reference free tables. The optional $prefix ensures the foreign key uses the default pro prefix while maintaining compatibility with the free table schema.