### PR TITLE
fix: expose insert id to created event

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -1287,12 +1287,6 @@ class QueryBuilder
             return false;
         }
 
-        // Set the PK from the auto-increment id when there is one; a table with a
-        // manual/composite key returns insert_id 0 yet the insert still succeeded.
-        if ($insertId = $this->lastInsertId()) {
-            $this->_model->setAttribute($pk, $insertId);
-        }
-
         $this->_model->fireEvent('saved');
 
         return $this->_model;
@@ -2176,6 +2170,14 @@ class QueryBuilder
         if (!empty(Connection::prop('last_error'))) {
             return false;
         }
+
+        // Sync the auto-increment id onto the model before `created` fires, so the
+        // event handler sees the new PK (Eloquent parity). A manual/composite key
+        // returns insert_id 0, so the original key is left untouched.
+        if ($this->_method === self::INSERT && ($insertId = $this->lastInsertId())) {
+            $this->_model->setAttribute($this->_model->getPrimaryKey(), $insertId);
+        }
+
         $this->dispatchEvent('post');
 
         return $this->_method === self::SELECT ? Connection::prop('last_result') : $result;

--- a/tests/CreatedEventHasInsertIdTest.php
+++ b/tests/CreatedEventHasInsertIdTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace BitApps\WPDatabase\Tests;
+
+use BitApps\WPDatabase\Tests\Fixtures\SavedEventUser;
+use FakeWpdb;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The `created` handler must see the auto-increment id on the model, matching
+ * Eloquent (which sets the key before firing `created`). Regression guard: the
+ * id was previously set only after exec() returned, so `created` saw an empty PK.
+ */
+final class CreatedEventHasInsertIdTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $GLOBALS['wpdb'] = new FakeWpdb();
+        SavedEventUser::resetCounters();
+    }
+
+    protected function tearDown(): void
+    {
+        $GLOBALS['wpdb'] = new FakeWpdb();
+        SavedEventUser::resetCounters();
+    }
+
+    public function testCreatedHandlerReceivesInsertId(): void
+    {
+        $GLOBALS['wpdb']->insert_id     = 42;
+        $GLOBALS['wpdb']->rows_affected = 1;
+
+        $user       = new SavedEventUser();
+        $user->name = 'Ada';
+        $user->save();
+
+        $this->assertSame(42, SavedEventUser::$createdSeenId, 'created must see the inserted id');
+        $this->assertSame(42, SavedEventUser::$savedSeenId, 'saved must see the inserted id');
+    }
+}

--- a/tests/Fixtures/SavedEventUser.php
+++ b/tests/Fixtures/SavedEventUser.php
@@ -18,6 +18,10 @@ class SavedEventUser extends Model
 
     public static $updatedCount = 0;
 
+    public static $createdSeenId = 'UNSET';
+
+    public static $savedSeenId = 'UNSET';
+
     protected $table = 'saved_event_users';
 
     protected $primaryKey = 'id';
@@ -26,18 +30,22 @@ class SavedEventUser extends Model
 
     public static function resetCounters()
     {
-        static::$savedCount   = 0;
-        static::$createdCount = 0;
-        static::$updatedCount = 0;
+        static::$savedCount    = 0;
+        static::$createdCount  = 0;
+        static::$updatedCount  = 0;
+        static::$createdSeenId = 'UNSET';
+        static::$savedSeenId   = 'UNSET';
     }
 
     protected static function boot()
     {
         static::saved(function ($model) {
             static::$savedCount++;
+            static::$savedSeenId = $model->id;
         });
         static::created(function ($model) {
             static::$createdCount++;
+            static::$createdSeenId = $model->id;
         });
         static::updated(function ($model) {
             static::$updatedCount++;


### PR DESCRIPTION
## Problem

The `created` model event fired **before** the auto-increment id was assigned to the model, so `created` handlers saw an empty primary key. `saved` was unaffected (it fires after the id was set).

Root cause: `created` dispatches inside `QueryBuilder::exec()` via `dispatchEvent('post')`, but `save()` only set the PK from `insert_id` *after* `exec()` returned.

This deviates from Laravel Eloquent, which assigns the key in `performInsert` before firing `created`.

## Fix

- `exec()` — after a successful query, when `_method === INSERT`, sync `insert_id` onto the model **before** the post event dispatches.
- `save()` — removed the now-redundant post-`exec()` id-set block.
- Manual/composite keys (`insert_id` 0) are left untouched — same as before.

## Tests

- New `CreatedEventHasInsertIdTest` asserts both `created` and `saved` receive the inserted id — red before, green after.
- Full suite: **259 pass**, no regressions.
- phpcs: zero new violations.

## Backward compatibility

Safe. Previously `created` received a null PK; nothing could depend on that. `saved` behavior unchanged.

Assisted-By: AI